### PR TITLE
Add resource type listing for `jgriff/hipchat-notification-resource`

### DIFF
--- a/jgriff-hipchat-notification-resource.yml
+++ b/jgriff-hipchat-notification-resource.yml
@@ -1,0 +1,5 @@
+name: hipchat-notification-resource
+repo: https://github.com/jgriff/hipchat-notification-resource
+container_image: jgriff/hipchat-notification-resource
+description: |
+    send notification messages to HipChat


### PR DESCRIPTION
Submission to add [`jgriff/hipchat-notification-resource`](https://github.com/jgriff/hipchat-notification-resource) to the resource listings.

**repo:** https://github.com/jgriff/hipchat-notification-resource
**image:** [`jgriff/hipchat-notification-resource`](https://hub.docker.com/r/jgriff/hipchat-notification-resource)