### PR TITLE
Add grafana-annotation-resource

### DIFF
--- a/alphagov-paas-grafana-annotation-resource.yml
+++ b/alphagov-paas-grafana-annotation-resource.yml
@@ -1,0 +1,5 @@
+name: grafana-annotation-resource
+repo: https://github.com/alphagov/paas-grafana-annotation-resource
+container_image: gdsre/grafana-annotation-resource
+description: |
+  Creates or updates a Grafana annotation


### PR DESCRIPTION
Spiritual successor to https://github.com/concourse/resource-types-website/pull/107 before repos were moved around.

----

What
----

Adds the [grafana-annotation-resource](https://github.com/alphagov/paas-grafana-annotation-resource) built by @alphagov

Used for creating and updating Grafana annotations:
![Screen Shot 2019-10-13 at 18 24 04](https://user-images.githubusercontent.com/1482692/66719382-b0717f80-ede6-11e9-86a6-7bd1caf9939b.png)
_Image of a requests per second dashboard with Grafana annotations showing deployment phases_

Why
---

We use Concourse for our many of our deployment pipelines, during which we run API and application availability tests.

It is useful to see the side-effects of these tests on our Grafana dashboards, e.g. elevated 5xx HTTP status codes. Given that Concourse is managing the pipeline, it makes sense to have a Concourse resource for creating/updating annotations.