### PR TITLE
Add aptly-cli, capistrano, and bitbucket-build-status resource types

### DIFF
--- a/SHyx0rmZ-aptly-cli.yml
+++ b/SHyx0rmZ-aptly-cli.yml
@@ -1,0 +1,5 @@
+name: aptly-cli
+repo: https://github.com/SHyx0rmZ/aptly-cli-resource
+container_image: shyxormz/aptly-cli-resource
+description: |
+  enables you to transfer packages between your job and an aptly repository

--- a/SHyx0rmZ-bitbucket-build-status-notification.yml
+++ b/SHyx0rmZ-bitbucket-build-status-notification.yml
@@ -1,0 +1,5 @@
+name: bitbucket-build-status
+repo: https://github.com/SHyx0rmZ/bitbucket-build-status-resource
+container_image: shyxormz/bitbucket-build-status-resource
+description: |
+  lets you update the build status for commits in Bitbucket

--- a/SHyx0rmZ-capistrano.yml
+++ b/SHyx0rmZ-capistrano.yml
@@ -1,0 +1,5 @@
+name: capistrano
+repo: https://github.com/SHyx0rmZ/capistrano-resource
+container_image: shyxormz/capistrano-resource
+description: |
+  enables you to run Capistrano deployments from your pipeline


### PR DESCRIPTION
This adds the three resource types I currently maintain, namely:
- aptly-cli
- bitbucket-build-status
- capistrano
