### PR TITLE
move cf-resource to new owner

### DIFF
--- a/concourse-cf-resource.yml
+++ b/concourse-cf-resource.yml
@@ -1,5 +1,5 @@
 name: cf
-repo: https://github.com/concourse/cf-resource
+repo: https://github.com/cloudfoundry-community/cf-resource
 container_image: concourse/cf-resource
 description: |
   Concourse resource for interacting with Cloud Foundry


### PR DESCRIPTION
- moving the cf-resource to cloudfoundry community after changing the ownership from concourse.