### PR TITLE
Add github-app-token

### DIFF
--- a/tenjaa-github-app-token-resource.yml
+++ b/tenjaa-github-app-token-resource.yml
@@ -1,0 +1,5 @@
+name: github-app-token
+repo: https://github.com/tenjaa/concourse-github-app-token
+container_image: tenjaa/concourse-github-app-token
+description: |
+  get an installation token for your GitHub App to access the GitHub API


### PR DESCRIPTION
A small resource to get a github installation token as a github app to be able to call the github api

Signed-off-by: Torben Neufeldt <torbenneufeldt@gmail.com>