### PR TITLE
Add registry-tag-resource

### DIFF
--- a/tlwr-registry-tag-resource.yml
+++ b/tlwr-registry-tag-resource.yml
@@ -1,0 +1,5 @@
+name: registry-tag
+repo: https://github.com/tlwr/registry-tag-resource
+container_image: ghcr.io/tlwr/registry-tag-resource
+description: |
+   a resource for image tags in a Docker registry


### PR DESCRIPTION
What
----

Adds `registry-tag` resource, which produces resource versions corresponding to tags in a docker image registry

Example
-------

Resource:

```
resources:
  - name: ruby-img-tag
    type: registry-tag
    icon: tag
    check_every: 15m
    source:
      uri: https://hub.docker.com/v2/repositories/library/ruby
      pages: 3
      regexp: '^[0-9]+[.][0-9]+[.][0-9]+-alpine$'
      semver:
        matcher: '>= 2.7'
```

Versions:

```
- tag: 3.0.1-alpine
- tag: 2.7.3-alpine
```

Version:

```
# ruby-img-tag/digest
sha256:742b443a544b78834d44c4d0f18c3a1cbe81186a448d161e969f00cace2937aa
```

```
# ruby-img-tag/tag
3.0.1-alpine
```