### PR TITLE
Replace the buggy 'keyval' resource with a fixed implementation

### DIFF
--- a/gstackio-key-value-resource.yml
+++ b/gstackio-key-value-resource.yml
@@ -1,0 +1,5 @@
+name: key-value
+repo: https://github.com/gstackio/keyval-resource
+container_image: gstack/keyval-resource
+description: |
+  A resource that passes key-value pairs between jobs, using plain files in some directory

--- a/moredhel-keyvalue-resource.yml
+++ b/moredhel-keyvalue-resource.yml
@@ -1,5 +1,0 @@
-name: keyvalue
-repo: https://github.com/moredhel/keyval-resource
-container_image: moredhel/keyval-resource
-description: |
-  An alternate implementation the Key Value resource, but conforms to the Kubernetes configmap pattern


### PR DESCRIPTION
The original resource by @moredhel is handy, but the `out` script does not work.
Indeed that resource improperly assumes that the `$1` argument contains an artifact directory where key-value pairs are to be found, whereas it is not the case.

The fixed implementation by Gstack that we provide here, adds two new parameters to the `out` script that allow the resource to properly work. Plus, the documentation has been fixed and completed. The Golang binaries have been compiled against latest Go v1.17 and dependencies have been bumped.

- GitHub: https://github.com/gstackio/keyval-resource
- Docker Hub: https://hub.docker.com/r/gstack/keyval-resource

That's why this PR is removing the buggy resource, so that Concourse users won't hit the issue with the older key-value resource.