### PR TITLE
fix/teams-notification: set descriptive name

### DIFF
--- a/navicore-teams-notification-resource.yml
+++ b/navicore-teams-notification-resource.yml
@@ -1,4 +1,4 @@
-name: git
+name: teams-notification
 repo: https://github.com/navicore/teams-notification-resource
 container_image: navicore/teams-notification-resource
 description: |


### PR DESCRIPTION
The teams-notification resource type by navicore currently has `git` as its name.
I presume this is a mistake given how often I click on it when navigating the resource type catalog while trying to get the git resource docs. 👀 

This is currently what I see on the resource catalog:
![image](https://user-images.githubusercontent.com/7764106/144915992-52d415ce-6689-4841-bc32-f413136cd7cb.png)

⚠️ Note ⚠️ 
I'm not affiliated with @navicore whatsoever, so if they have some other name entirely they'd like to use, I can edit my PR accordingly (I'm also cool with having this PR closed and them take over it entirely). I'm also leaving the `Allow edits by maintainers` box checked if y'all would rather take it over yourselves.