### PR TITLE
concourse-webhook-resource

### DIFF
--- a/ardavanhashemzadeh-concourse-webhook-resource.yml
+++ b/ardavanhashemzadeh-concourse-webhook-resource.yml
@@ -1,0 +1,5 @@
+name: concourse-webhook-resource
+repo: https://github.com/ardavanhashemzadeh/concourse-webhook-resource
+container_image: ghcr.io/ardavanhashemzadeh/concourse-webhook-resource
+description: |
+  Use files in git repo to track and throttle API calls as pipeline trigger.

--- a/kdihalas-digitalocean-kubernetes-resource.yml
+++ b/kdihalas-digitalocean-kubernetes-resource.yml
@@ -1,0 +1,5 @@
+name: digitalocean-kubernetes-resource
+repo: https://kdihalas.github.io/concourse-do-kubernetes-resource/
+container_image: kdihalas/digitalocean-kubernetes-resource
+description: |
+  Create, update and delete Digitalocean Kubernetes Clusters.


### PR DESCRIPTION
Use files in git repo to track and throttle API calls as pipeline trigger.

Signed-off-by: Ardavan Hashemzadeh <ardy.hash+mzadehgit.com>