### PR TITLE
Take over maintenance of the github-pr-resource

### DIFF
--- a/cfcommunity-github-pr-resource.yml
+++ b/cfcommunity-github-pr-resource.yml
@@ -1,0 +1,5 @@
+name: github-pr
+repo: https://github.com/cloudfoundry-community/github-pr-resource
+container_image: cfcommunity/github-pr-resource
+description: |
+  Let Concourse pipelines to interact with GitHub Pull Requests

--- a/telia-oss-github-pr-resource.yml
+++ b/telia-oss-github-pr-resource.yml
@@ -1,5 +1,0 @@
-name: github-pr
-repo: https://github.com/telia-oss/github-pr-resource
-container_image: teliaoss/github-pr-resource
-description: |
-  Github pull request resource for Concourse


### PR DESCRIPTION
Hi there,

I've set up a Concourse pipeline for maintaining the `github-pr-resource`, leveraging the already-existing fork done by VMware in the `cloudfoundry-comunity` org.

With [the 1.7.0 release just out](https://github.com/cloudfoundry-community/github-pr-resource/releases), I've demonstrated I could build the resource using recent Golang and have it run on recent Alpine. The resulting released image is there: [cfcommunity/github-pr-resource](https://hub.docker.com/r/cfcommunity/github-pr-resource). With the help of [pipeline templates](https://github.com/cloudfoundry-community/pipeline-templates) (that I'm also maintaining), I've tailored nice Concourse pipelines that can bump deps, build, test and publish easily images for Concourse resources.

Later on with `cloudfoundry-comunity/github-pr-resource`, I plan to bump the dependencies further, and review and accept more pending PRs.

For now, the [telia-oss repo](https://github.com/telia-oss/github-pr-resource) hasn't had any new commit since February 2021. Issues & PRs have dramatically piled up there, and people have (legitimately) become bitter about that important resource not being properly maintained. Long story short, it has been inactive for enough time now, and the community should focus on some fork where the code can be submitted, tested, reviewed and accepted.

That's what I'm suggesting with the cloudfoundry-comunity fork today.

Best,
Benjamin