### PR TITLE
Add `duct-tape-resource`

### DIFF
--- a/homeport-duct-tape-resource.yml
+++ b/homeport-duct-tape-resource.yml
@@ -1,0 +1,5 @@
+name: duct-tape-resource
+repo: https://github.com/homeport/duct-tape-resource
+container_image: ghcr.io/homeport/duct-tape-resource
+description: |
+  Generic custom Concourse resource with which one can define the check, in, and out as inline scripts right in the pipeline resource definition. It is for when you quickly need a Concourse resource for a specific task, but writing one from scratch would take too long. With this resource, one can glue things together.


### PR DESCRIPTION
Add `duct-tape-resource`, a generic custom Concourse resource to write custom resources on the fly as inline shell scripts in the pipeline definition itself.

Example:
```yaml
resources:
- name: foobar
  type: duct-tape-resource
  icon: application-variable
  check_every: 20m
  source:
    check:
      env:
        ACCESS_KEY: ((bar))

      # only run once per worker
      before: |
        #!/bin/bash
        run install of sometool

      run: |
        #!/bin/bash
        run some shell commands to get things
        
        # output of this tool will be treated a ref/version of the resource, i.e. list Git commits so it would act like a Git resource
        sometool --list
```

The resource is in active use and proved quite useful, because you don't need to setup a full fledged custom Concourse resource with container images, but instead quickly assemble what you need. Also useful to be used to test pipelines with a custom resource before committing to writing a standalone custom resource.