### PR TITLE
Create ardavanhashemzadeh-metadata-resource

### DIFF
--- a/ardavanhashemzadeh-metadata-resource
+++ b/ardavanhashemzadeh-metadata-resource
@@ -1,0 +1,5 @@
+name: metadata-resource
+repo: https://github.com/ardavanhashemzadeh/metadata-resource
+container_image: ghcr.io/ardavanhashemzadeh/metadata-resource:main
+description: |
+  Simple concourse resource which saves build metadata to a file which may be used by tasks because by default the environment variables are only available to resources and not tasks.


### PR DESCRIPTION
By default build metadata environment variables are only available to resources during get and put operations, this resource will save the build metadata to a file which tasks may use as tasks do not have this information available to them by default.